### PR TITLE
Update testing process to follow kotti + bootstrap upgrades

### DIFF
--- a/kotti_calendar/conftest.py
+++ b/kotti_calendar/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = "kotti"

--- a/kotti_calendar/tests/test_widgets.py
+++ b/kotti_calendar/tests/test_widgets.py
@@ -4,6 +4,9 @@ from datetime import timedelta
 from pyramid.threadlocal import get_current_registry
 from kotti.testing import FunctionalTestBase
 from kotti.testing import DummyRequest
+from kotti.testing import user
+from kotti.tests import browser
+import pytest
 
 
 class TestUpcomingEventsWidget(FunctionalTestBase):
@@ -48,8 +51,9 @@ class TestUpcomingEventsWidget(FunctionalTestBase):
         assert events[1].title == u'Event 2'
         assert events[1].start == now + timedelta(1)
 
-    def test_render(self):
-        browser = self.login_testbrowser()
+    @user('admin')
+    @pytest.fixture(autouse=True)
+    def test_render(self, browser):
         ctrl = browser.getControl
 
         browser.getLink(u'Calendar').click()
@@ -66,8 +70,9 @@ class TestUpcomingEventsWidget(FunctionalTestBase):
         assert 'This is my Event' in browser.contents
         assert 'Aug 22, 2112 8:00:00 PM' in browser.contents
 
-    def test_settings(self):
-        browser = self.login_testbrowser()
+    @user('admin')
+    @pytest.fixture(autouse=True)
+    def test_settings(self, browser):
         ctrl = browser.getControl
         browser.getLink(u'Calendar').click()
         ctrl('Title').value = u'Calendar'

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,9 @@ addopts =
   --ignore=kotti_calendar/templates/
   kotti_calendar/
 python_files = test*py
+markers =
+    user: mark test to be run as the given user
+usefixtures = browser
 
 [minify_css]
 sources = kotti/static/*.css


### PR DESCRIPTION
We need to use the user/browser marker + fixtures.
- Update the setup.cfg to declare them
- Use kotti testing plugin (conftest.py)
- Use Marker + fixture in tests in place of the outdated browser login method

This is not a sufficient fix to make tests pass, but it's a start
